### PR TITLE
border thickness value, fixed

### DIFF
--- a/qframelesswindow/utils/win32_utils.py
+++ b/qframelesswindow/utils/win32_utils.py
@@ -1,4 +1,5 @@
 # coding:utf-8
+import ctypes
 from ctypes import Structure, byref, sizeof, windll
 from ctypes.wintypes import DWORD, HWND, LPARAM, RECT, UINT
 from platform import platform
@@ -70,7 +71,7 @@ def getMonitorInfo(hWnd, dwFlags):
     return win32api.GetMonitorInfo(monitor)
 
 
-def getResizeBorderThickness(hWnd):
+def getResizeBorderThickness(hWnd, horizontal=True):
     """ get resize border thickness of widget
 
     Parameters
@@ -85,8 +86,13 @@ def getResizeBorderThickness(hWnd):
     if not window:
         return 0
 
-    result = win32api.GetSystemMetrics(
-        win32con.SM_CXSIZEFRAME) + win32api.GetSystemMetrics(92)
+    user32 = ctypes.windll.user32
+    user32.GetSystemMetricsForDpi.argtypes = [ctypes.c_int, ctypes.c_uint]
+    user32.GetSystemMetricsForDpi.restype = ctypes.c_int
+
+    frame = win32con.SM_CXSIZEFRAME if horizontal else win32con.SM_CYSIZEFRAME
+    dpi = user32.GetDpiForWindow(hWnd)
+    result = user32.GetSystemMetricsForDpi(frame, dpi) + user32.GetSystemMetricsForDpi(92, dpi)
 
     if result > 0:
         return result

--- a/qframelesswindow/utils/win32_utils.py
+++ b/qframelesswindow/utils/win32_utils.py
@@ -1,5 +1,4 @@
 # coding:utf-8
-import ctypes
 from ctypes import Structure, byref, sizeof, windll
 from ctypes.wintypes import DWORD, HWND, LPARAM, RECT, UINT
 from platform import platform
@@ -86,9 +85,7 @@ def getResizeBorderThickness(hWnd, horizontal=True):
     if not window:
         return 0
 
-    user32 = ctypes.windll.user32
-    user32.GetSystemMetricsForDpi.argtypes = [ctypes.c_int, ctypes.c_uint]
-    user32.GetSystemMetricsForDpi.restype = ctypes.c_int
+    user32 = windll.user32
 
     frame = win32con.SM_CXSIZEFRAME if horizontal else win32con.SM_CYSIZEFRAME
     dpi = user32.GetDpiForWindow(hWnd)

--- a/qframelesswindow/windows/__init__.py
+++ b/qframelesswindow/windows/__init__.py
@@ -108,15 +108,15 @@ class WindowsFramelessWindow(QWidget):
             isMax = win_utils.isMaximized(msg.hWnd)
             isFull = win_utils.isFullScreen(msg.hWnd)
 
-            borderWidth = win32api.GetSystemMetrics(win32con.SM_CXSIZEFRAME)
-            borderHeight = win32api.GetSystemMetrics(win32con.SM_CYSIZEFRAME)
-
             # adjust the size of client rect
             if isMax and not isFull:
-                rect.top += borderHeight
-                rect.left += borderWidth
-                rect.right -= borderWidth
-                rect.bottom -= borderHeight
+                ty = win_utils.getResizeBorderThickness(msg.hWnd, False)
+                rect.top += ty
+                rect.bottom -= ty
+
+                tx = win_utils.getResizeBorderThickness(msg.hWnd, True)
+                rect.left += tx
+                rect.right -= tx
 
             # handle the situation that an auto-hide taskbar is enabled
             if (isMax or isFull) and Taskbar.isAutoHide():

--- a/qframelesswindow/windows/__init__.py
+++ b/qframelesswindow/windows/__init__.py
@@ -3,6 +3,7 @@ import sys
 from ctypes import cast
 from ctypes.wintypes import LPRECT, MSG
 
+import win32api
 import win32con
 import win32gui
 from PyQt5.QtCore import Qt
@@ -107,13 +108,15 @@ class WindowsFramelessWindow(QWidget):
             isMax = win_utils.isMaximized(msg.hWnd)
             isFull = win_utils.isFullScreen(msg.hWnd)
 
+            borderWidth = win32api.GetSystemMetrics(win32con.SM_CXSIZEFRAME)
+            borderHeight = win32api.GetSystemMetrics(win32con.SM_CYSIZEFRAME)
+
             # adjust the size of client rect
             if isMax and not isFull:
-                thickness = win_utils.getResizeBorderThickness(msg.hWnd)
-                rect.top += thickness
-                rect.left += thickness
-                rect.right -= thickness
-                rect.bottom -= thickness
+                rect.top += borderHeight
+                rect.left += borderWidth
+                rect.right -= borderWidth
+                rect.bottom -= borderHeight
 
             # handle the situation that an auto-hide taskbar is enabled
             if (isMax or isFull) and Taskbar.isAutoHide():


### PR DESCRIPTION
I just found a bug related to the border thickness.
Here you adjust the size of the client area. The problem is that the border width and border height aren't always equal. That's why in win32 we see SM_CXSIZEFRAME and SM_CYSIZEFRAME. So using the same value for horizontal and vertical adjustments, causes a bug.
```python
def getResizeBorderThickness(hWnd):
    window = findWindow(hWnd)
    if not window:
        return 0

    result = win32api.GetSystemMetrics(
        win32con.SM_CXSIZEFRAME) + win32api.GetSystemMetrics(92)

    if result > 0:
        return result

    thickness = 8 if QtWin.isCompositionEnabled() else 4
    return round(thickness*window.devicePixelRatio())

# adjust the size of client rect
if isMax and not isFull:
    thickness = win_utils.getResizeBorderThickness(msg.hWnd)
    rect.top += thickness
    rect.left += thickness
    rect.right -= thickness
    rect.bottom -= thickness
```

**Before fixing the bug**
![Screenshot (34)](https://user-images.githubusercontent.com/62795984/224492731-2ee881df-7b54-4246-acde-546d2bd80cd9.png)

**After**
![Screenshot (35)](https://user-images.githubusercontent.com/62795984/224492730-b95cf94a-a939-45ba-9465-ada247dfd6ea.png)

***Here is the solution:***
```python
borderWidth = win32api.GetSystemMetrics(win32con.SM_CXSIZEFRAME)
borderHeight = win32api.GetSystemMetrics(win32con.SM_CYSIZEFRAME)

# adjust the size of client rect
if isMax and not isFull:
    rect.top += borderHeight
    rect.left += borderWidth
    rect.right -= borderWidth
    rect.bottom -= borderHeight
```

Btw, thank you for publishing this great and useful package.

