### PR TITLE
DPI Aware & Theme aware BORDER_WIDTH

### DIFF
--- a/qframelesswindow/utils/win32_utils.py
+++ b/qframelesswindow/utils/win32_utils.py
@@ -1,4 +1,5 @@
 # coding:utf-8
+import ctypes
 from ctypes import Structure, byref, sizeof, windll
 from ctypes.wintypes import DWORD, HWND, LPARAM, RECT, UINT
 from platform import platform
@@ -70,7 +71,7 @@ def getMonitorInfo(hWnd, dwFlags):
     return win32api.GetMonitorInfo(monitor)
 
 
-def getResizeBorderThickness(hWnd):
+def getResizeBorderThickness(hWnd, horizontal=True):
     """ get resize border thickness of widget
 
     Parameters
@@ -85,8 +86,13 @@ def getResizeBorderThickness(hWnd):
     if not window:
         return 0
 
-    result = win32api.GetSystemMetrics(
-        win32con.SM_CXSIZEFRAME) + win32api.GetSystemMetrics(92)
+    user32 = ctypes.windll.user32
+    user32.GetSystemMetricsForDpi.argtypes = [ctypes.c_int, ctypes.c_uint]
+    user32.GetSystemMetricsForDpi.restype = ctypes.c_int
+
+    frame = win32con.SM_CXSIZEFRAME if horizontal else win32con.SM_CYSIZEFRAME
+    dpi = user32.GetDpiForWindow(hWnd)
+    result = user32.GetSystemMetricsForDpi(frame, dpi) + user32.GetSystemMetricsForDpi(92, dpi)
 
     if result > 0:
         return result

--- a/qframelesswindow/utils/win32_utils.py
+++ b/qframelesswindow/utils/win32_utils.py
@@ -1,5 +1,4 @@
 # coding:utf-8
-import ctypes
 from ctypes import Structure, byref, sizeof, windll
 from ctypes.wintypes import DWORD, HWND, LPARAM, RECT, UINT
 from platform import platform
@@ -86,9 +85,7 @@ def getResizeBorderThickness(hWnd, horizontal=True):
     if not window:
         return 0
 
-    user32 = ctypes.windll.user32
-    user32.GetSystemMetricsForDpi.argtypes = [ctypes.c_int, ctypes.c_uint]
-    user32.GetSystemMetricsForDpi.restype = ctypes.c_int
+    user32 = windll.user32
 
     frame = win32con.SM_CXSIZEFRAME if horizontal else win32con.SM_CYSIZEFRAME
     dpi = user32.GetDpiForWindow(hWnd)

--- a/qframelesswindow/windows/__init__.py
+++ b/qframelesswindow/windows/__init__.py
@@ -108,15 +108,15 @@ class WindowsFramelessWindow(QWidget):
             isMax = win_utils.isMaximized(msg.hWnd)
             isFull = win_utils.isFullScreen(msg.hWnd)
 
-            borderWidth = win32api.GetSystemMetrics(win32con.SM_CXSIZEFRAME)
-            borderHeight = win32api.GetSystemMetrics(win32con.SM_CYSIZEFRAME)
-
             # adjust the size of client rect
             if isMax and not isFull:
-                rect.top += borderHeight
-                rect.left += borderWidth
-                rect.right -= borderWidth
-                rect.bottom -= borderHeight
+                ty = win_utils.getResizeBorderThickness(msg.hWnd, False)
+                rect.top += ty
+                rect.bottom -= ty
+
+                tx = win_utils.getResizeBorderThickness(msg.hWnd, True)
+                rect.left += tx
+                rect.right -= tx
 
             # handle the situation that an auto-hide taskbar is enabled
             if (isMax or isFull) and Taskbar.isAutoHide():

--- a/qframelesswindow/windows/__init__.py
+++ b/qframelesswindow/windows/__init__.py
@@ -1,4 +1,5 @@
 # coding:utf-8
+import ctypes
 import sys
 from ctypes import cast
 from ctypes.wintypes import LPRECT, MSG
@@ -20,8 +21,6 @@ from .window_effect import WindowsWindowEffect
 
 class WindowsFramelessWindow(QWidget):
     """  Frameless window for Windows system """
-
-    BORDER_WIDTH = 5
 
     def __init__(self, parent=None):
         super().__init__(parent=parent)
@@ -79,10 +78,17 @@ class WindowsFramelessWindow(QWidget):
             xPos = pos.x() - self.x()
             yPos = pos.y() - self.y()
             w, h = self.width(), self.height()
-            lx = xPos < self.BORDER_WIDTH
-            rx = xPos > w - self.BORDER_WIDTH
-            ty = yPos < self.BORDER_WIDTH
-            by = yPos > h - self.BORDER_WIDTH
+            user32 = ctypes.windll.user32
+            dpi = user32.GetDpiForWindow(msg.hWnd)
+            SM_CXPADDEDBORDER = 92
+            borderWidth = user32.GetSystemMetricsForDpi(win32con.SM_CXSIZEFRAME, dpi) + user32.GetSystemMetricsForDpi(
+                SM_CXPADDEDBORDER, dpi)
+            borderHeight = user32.GetSystemMetricsForDpi(win32con.SM_CYSIZEFRAME, dpi) + user32.GetSystemMetricsForDpi(
+                SM_CXPADDEDBORDER, dpi)
+            lx = xPos < borderWidth
+            rx = xPos > w - borderWidth
+            ty = yPos < borderHeight
+            by = yPos > h - borderHeight
             if lx and ty:
                 return True, win32con.HTTOPLEFT
             elif rx and by:

--- a/qframelesswindow/windows/__init__.py
+++ b/qframelesswindow/windows/__init__.py
@@ -3,6 +3,7 @@ import sys
 from ctypes import cast
 from ctypes.wintypes import LPRECT, MSG
 
+import win32api
 import win32con
 import win32gui
 from PyQt5.QtCore import Qt
@@ -107,13 +108,15 @@ class WindowsFramelessWindow(QWidget):
             isMax = win_utils.isMaximized(msg.hWnd)
             isFull = win_utils.isFullScreen(msg.hWnd)
 
+            borderWidth = win32api.GetSystemMetrics(win32con.SM_CXSIZEFRAME)
+            borderHeight = win32api.GetSystemMetrics(win32con.SM_CYSIZEFRAME)
+
             # adjust the size of client rect
             if isMax and not isFull:
-                thickness = win_utils.getResizeBorderThickness(msg.hWnd)
-                rect.top += thickness
-                rect.left += thickness
-                rect.right -= thickness
-                rect.bottom -= thickness
+                rect.top += borderHeight
+                rect.left += borderWidth
+                rect.right -= borderWidth
+                rect.bottom -= borderHeight
 
             # handle the situation that an auto-hide taskbar is enabled
             if (isMax or isFull) and Taskbar.isAutoHide():


### PR DESCRIPTION
Since different screens might have different scale factors, it would be better to use a DPI Aware value rather than self.BORDER_WIDTH = 10. So I removed this static attribute and I added the following code to calculate the border width and border height.

```python
user32 = ctypes.windll.user32
dpi = user32.GetDpiForWindow(msg.hWnd)
borderWidth = user32.GetSystemMetricsForDpi(win32con.SM_CXSIZEFRAME, dpi) + user32.GetSystemMetricsForDpi(
    92, dpi)
borderHeight = user32.GetSystemMetricsForDpi(win32con.SM_CYSIZEFRAME, dpi) + user32.GetSystemMetricsForDpi(
    92, dpi)

if msg.message == win32con.WM_NCHITTEST:
    w, h = self.width(), self.height()
    lx = x < borderWidth
    rx = x > w - 2 * borderWidth
    ty = y < borderHeight
    by = y > h - borderHeight

    if lx and ty:
        return True, win32con.HTTOPLEFT
    if rx and by:
        return True, win32con.HTBOTTOMRIGHT
    if rx and ty:
        return True, win32con.HTTOPRIGHT
    if lx and by:
        return True, win32con.HTBOTTOMLEFT
    if ty:
        return True, win32con.HTTOP
    if by:
        return True, win32con.HTBOTTOM
    if lx:
        return True, win32con.HTLEFT
    if rx:
        return True, win32con.HTRIGHT
```