### PR TITLE
Fixed a bug that caused a dead zone on the far right due to incorrect acquisition of the window frame width.

### DIFF
--- a/qframelesswindow/__init__.py
+++ b/qframelesswindow/__init__.py
@@ -12,7 +12,7 @@ Examples are available at https://github.com/zhiyiYo/PyQt-Frameless-Window/tree/
 :license: LGPLv3, see LICENSE for more details.
 """
 
-__version__ = "0.3.7"
+__version__ = "0.3.8"
 
 import sys
 

--- a/qframelesswindow/windows/__init__.py
+++ b/qframelesswindow/windows/__init__.py
@@ -86,7 +86,8 @@ class WindowsFramelessWindow(QWidget):
             pos = QCursor.pos()
             xPos = pos.x() - self.x()
             yPos = pos.y() - self.y()
-            w, h = self.width(), self.height()
+            w = self.frameGeometry().width()
+            h = self.frameGeometry().height()
 
             # fixes https://github.com/zhiyiYo/PyQt-Frameless-Window/issues/98
             bw = 0 if win_utils.isMaximized(msg.hWnd) or win_utils.isFullScreen(msg.hWnd) else self.BORDER_WIDTH


### PR DESCRIPTION
源代码获取的宽度与高度只是可视区域的宽度与高度，因此存在鼠标坐标与预期不符的情况，导致可视区域最右侧被判定为窗口外