### PR TITLE
Fix the window can be moved after double clicking to change its state (#128)

### DIFF
--- a/qframelesswindow/titlebar/__init__.py
+++ b/qframelesswindow/titlebar/__init__.py
@@ -64,6 +64,9 @@ class TitleBarBase(QWidget):
             self.window().showNormal()
         else:
             self.window().showMaximized()
+        if sys.platform == "win32":
+            from ..utils.win32_utils import releaseMouseLeftButton
+            releaseMouseLeftButton(self.window().winId())
 
     def _isDragRegion(self, pos):
         """ Check whether the position belongs to the area where dragging is allowed """

--- a/qframelesswindow/titlebar/__init__.py
+++ b/qframelesswindow/titlebar/__init__.py
@@ -64,6 +64,7 @@ class TitleBarBase(QWidget):
             self.window().showNormal()
         else:
             self.window().showMaximized()
+            
         if sys.platform == "win32":
             from ..utils.win32_utils import releaseMouseLeftButton
             releaseMouseLeftButton(self.window().winId())

--- a/qframelesswindow/utils/win32_utils.py
+++ b/qframelesswindow/utils/win32_utils.py
@@ -214,6 +214,7 @@ def releaseMouseLeftButton(hWnd, x=0, y=0):
         lp
     )
 
+
 class APPBARDATA(Structure):
     _fields_ = [
         ('cbSize',            DWORD),

--- a/qframelesswindow/utils/win32_utils.py
+++ b/qframelesswindow/utils/win32_utils.py
@@ -192,6 +192,28 @@ def isWin7():
     return "Windows-7" in platform()
 
 
+def releaseMouseLeftButton(hWnd, x=0, y=0):
+    """ release mouse left button at (x, y)
+
+    Parameters
+    ----------
+    hWnd: int or `sip.voidptr`
+        window handle
+        
+    x: int
+        mouse x pos
+        
+    y: int
+        mouse y pos
+    """
+    lp = (y & 0xFFFF) << 16 | (x & 0xFFFF)
+    win32api.SendMessage(
+        hWnd,
+        win32con.WM_LBUTTONUP,
+        0,
+        lp
+    )
+
 class APPBARDATA(Structure):
     _fields_ = [
         ('cbSize',            DWORD),


### PR DESCRIPTION
修复了在Windows上双击标题栏后不松开鼠标左键拖拽窗口时可以移动窗口的bug