### PR TITLE
修复 Linux 下拖动窗口上部边框无法正常调整大小的问题 (#160)

### DIFF
--- a/qframelesswindow/titlebar/__init__.py
+++ b/qframelesswindow/titlebar/__init__.py
@@ -80,7 +80,7 @@ class TitleBarBase(QWidget):
             if button.isVisible():
                 width += button.width()
 
-        return 0 < pos.x() < self.width() - width
+        return self.window().BORDER_WIDTH < pos.x() < self.width() - width and pos.y() > self.window().BORDER_WIDTH
 
     def _hasButtonPressed(self):
         """ whether any button is pressed """


### PR DESCRIPTION
为 `TitleBarBase` 类中的 `_isDragRegion` 函数加上关于 `BORDER_WIDTH` 的判断