### PR TITLE
在 TitleBar 类中处理 mouseReleaseEvent 以实现 Windows 右键菜单 (#176)

### DIFF
--- a/qframelesswindow/titlebar/__init__.py
+++ b/qframelesswindow/titlebar/__init__.py
@@ -91,7 +91,8 @@ class TitleBarBase(QWidget):
             )
             if command:
                 windll.user32.SendMessageW(self.window().winId(), 0x0112, command, 0)
-
+        super().mouseReleaseEvent(e)
+        
     def __toggleMaxState(self):
         """ Toggles the maximization state of the window and change icon """
         if self.window().isMaximized():

--- a/qframelesswindow/titlebar/__init__.py
+++ b/qframelesswindow/titlebar/__init__.py
@@ -1,10 +1,6 @@
 # coding:utf-8
 import sys
 
-from PySide6.QtCore import QPoint
-from PySide6.QtGui import QMouseEvent
-from PySide6.QtWidgets import QApplication
-
 from PySide6.QtCore import Qt, QEvent
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QLabel, QHBoxLayout, QWidget
@@ -61,6 +57,40 @@ class TitleBarBase(QWidget):
             return
 
         startSystemMove(self.window(), e.globalPos())
+
+    def mouseReleaseEvent(self, e):
+        if sys.platform == "win32" and e.button() == Qt.RightButton:
+            from ctypes import windll
+            import win32con
+            systemMenu = windll.user32.GetSystemMenu(self.window().winId(), False)
+            if self.window()._isResizeEnabled:
+                windll.user32.EnableMenuItem(systemMenu, win32con.SC_SIZE, win32con.MF_ENABLED)
+                if self.window().isMaximized():
+                    windll.user32.EnableMenuItem(systemMenu, win32con.SC_MAXIMIZE, win32con.MF_GRAYED)
+                    windll.user32.EnableMenuItem(systemMenu, win32con.SC_MOVE, win32con.MF_GRAYED)
+                    windll.user32.EnableMenuItem(systemMenu, win32con.SC_SIZE, win32con.MF_GRAYED)
+                    windll.user32.EnableMenuItem(systemMenu, win32con.SC_RESTORE, win32con.MF_ENABLED)
+                else:
+                    windll.user32.EnableMenuItem(systemMenu, win32con.SC_MAXIMIZE, win32con.MF_ENABLED)
+                    windll.user32.EnableMenuItem(systemMenu, win32con.SC_MOVE, win32con.MF_ENABLED)
+                    windll.user32.EnableMenuItem(systemMenu, win32con.SC_SIZE, win32con.MF_ENABLED)
+                    windll.user32.EnableMenuItem(systemMenu, win32con.SC_RESTORE, win32con.MF_GRAYED)
+            else:
+                windll.user32.EnableMenuItem(systemMenu, win32con.SC_MAXIMIZE, win32con.MF_GRAYED)
+                windll.user32.EnableMenuItem(systemMenu, win32con.SC_MOVE, win32con.MF_GRAYED)
+                windll.user32.EnableMenuItem(systemMenu, win32con.SC_SIZE, win32con.MF_GRAYED)
+                windll.user32.EnableMenuItem(systemMenu, win32con.SC_RESTORE, win32con.MF_GRAYED)
+
+            command = windll.user32.TrackPopupMenuEx(
+                systemMenu,
+                win32con.TPM_LEFTALIGN | win32con.TPM_RETURNCMD,
+                e.globalX(),
+                e.globalY(),
+                self.window().winId(),
+                None
+            )
+            if command:
+                windll.user32.SendMessageW(self.window().winId(), 0x0112, command, 0)
 
     def __toggleMaxState(self):
         """ Toggles the maximization state of the window and change icon """

--- a/qframelesswindow/titlebar/__init__.py
+++ b/qframelesswindow/titlebar/__init__.py
@@ -90,7 +90,7 @@ class TitleBarBase(QWidget):
                 None
             )
             if command:
-                windll.user32.SendMessageW(self.window().winId(), 0x0112, command, 0)
+                windll.user32.PostMessageW(self.window().winId(), 0x0112, command, 0)
         super().mouseReleaseEvent(e)
         
     def __toggleMaxState(self):

--- a/qframelesswindow/titlebar/__init__.py
+++ b/qframelesswindow/titlebar/__init__.py
@@ -62,7 +62,7 @@ class TitleBarBase(QWidget):
         if sys.platform == "win32" and e.button() == Qt.RightButton:
             from ctypes import windll
             import win32con
-            systemMenu = windll.user32.GetSystemMenu(self.window().winId(), False)
+            systemMenu = windll.user32.GetSystemMenu(int(self.window().winId()), False)
             if self.window()._isResizeEnabled:
                 windll.user32.EnableMenuItem(systemMenu, win32con.SC_SIZE, win32con.MF_ENABLED)
                 if self.window().isMaximized():
@@ -86,7 +86,7 @@ class TitleBarBase(QWidget):
                 win32con.TPM_LEFTALIGN | win32con.TPM_RETURNCMD,
                 e.globalX(),
                 e.globalY(),
-                self.window().winId(),
+                int(self.window().winId()),
                 None
             )
             if command:


### PR DESCRIPTION
* 可以根据窗口状态动态启用或禁用菜单项
* close #176 

![image](https://github.com/user-attachments/assets/ba516f6f-daa8-4eba-86bc-089f71985527)
![image](https://github.com/user-attachments/assets/caf39920-3366-458c-adcd-e4b44a1e16e3)
![image](https://github.com/user-attachments/assets/770a576c-125c-4749-9f5c-5bf235087d67)
