### PR TITLE
修复 Windows 下双屏用户主显示器在副显示器右边时导致的光标为可拖拽状态的问题

### DIFF
--- a/qframelesswindow/utils/win32_utils.py
+++ b/qframelesswindow/utils/win32_utils.py
@@ -252,6 +252,22 @@ def releaseMouseLeftButton(hWnd, x=0, y=0):
     win32api.SendMessage(int(hWnd), win32con.WM_LBUTTONUP, 0, lp)
 
 
+def GET_X_LPARAM(lParam):
+    """ Retrieves the signed x-coordinate from LPARAM """
+    x = lParam & 0xFFFF
+    if x >= 0x8000:
+        x -= 0x10000
+    return x
+
+
+def GET_Y_LPARAM(lParam):
+    """ Retrieves the signed y-coordinate from LPARAM """
+    y = lParam >> 16
+    if y >= 0x8000:
+        y -= 0x10000
+    return y
+
+
 class APPBARDATA(Structure):
     _fields_ = [
         ('cbSize',            DWORD),

--- a/qframelesswindow/windows/__init__.py
+++ b/qframelesswindow/windows/__init__.py
@@ -12,7 +12,7 @@ from PyQt5.QtWidgets import QApplication, QWidget
 
 from ..titlebar import TitleBar
 from ..utils import win32_utils as win_utils
-from ..utils.win32_utils import Taskbar, isSystemBorderAccentEnabled, getSystemAccentColor
+from ..utils.win32_utils import Taskbar, isSystemBorderAccentEnabled, getSystemAccentColor, GET_X_LPARAM, GET_Y_LPARAM
 from .c_structures import LPNCCALCSIZE_PARAMS
 from .window_effect import WindowsWindowEffect
 
@@ -117,7 +117,7 @@ class WindowsFramelessWindow(QWidget):
             return super().nativeEvent(eventType, message)
 
         if msg.message == win32con.WM_NCHITTEST and self._isResizeEnabled:
-            xPos, yPos = win32gui.ScreenToClient(msg.hWnd, (msg.lParam & 65535, msg.lParam >> 16))
+            xPos, yPos = win32gui.ScreenToClient(msg.hWnd, (GET_X_LPARAM(msg.lParam), GET_Y_LPARAM(msg.lParam)))
             clientRect = win32gui.GetClientRect(msg.hWnd)
 
             w = clientRect[2] - clientRect[0]


### PR DESCRIPTION
由于具有多个监视器的系统可以具有负 x 坐标和 y 坐标, 根据 https://learn.microsoft.com/zh-cn/windows/win32/inputdev/wm-nchittest 文档, 使用 `GET_X_LPARAM` 和 `GET_X_LPARAM` 宏来获取鼠标位置以解决 LOWORD 和 HIWORD 会将坐标视为无符号数量问题导致的双屏用户主显示器在副显示器右边时导致的光标为可拖拽状态的问题